### PR TITLE
Fix spelling of ingredient summary function

### DIFF
--- a/be/internal/handlers/tools.go
+++ b/be/internal/handlers/tools.go
@@ -28,7 +28,7 @@ func (h *HandlerTools) handleIngredientSummaryPOST(w http.ResponseWriter, r *htt
 		return errors.New("invalid JSON body")
 	}
 
-	summary, err := h.s.CaclucateIngredientSummary(r.Context(), input)
+    summary, err := h.s.CalculateIngredientSummary(r.Context(), input)
 	if err != nil {
 		return errors.New("failed to calculate ingredient summary: " + err.Error())
 	}

--- a/be/internal/service/tools.go
+++ b/be/internal/service/tools.go
@@ -18,7 +18,7 @@ func NewServiceTools() *ServiceTools {
 	db := repo.GetDatabaseInstance().DB
 	return &ServiceTools{db: db}
 }
-func (s *ServiceTools) CaclucateIngredientSummary(ctx context.Context, input model.IngredientInDishPut) (model.NutritionSummary, error) {
+func (s *ServiceTools) CalculateIngredientSummary(ctx context.Context, input model.IngredientInDishPut) (model.NutritionSummary, error) {
 	var total model.NutritionSummary
 
 	var kcal, proteins, fats, carbs, default_amount float64


### PR DESCRIPTION
## Summary
- rename `CaclucateIngredientSummary` to `CalculateIngredientSummary`
- update handler to use the new function name

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687a12840ec883328fecfc5d0c5c2f46