### PR TITLE
Fix zero-division in day summary calculation

### DIFF
--- a/be/internal/service/tools.go
+++ b/be/internal/service/tools.go
@@ -119,10 +119,18 @@ func (s *ServiceTools) CalculateDaySummary(ctx context.Context, dishes []model.D
 	}
 
 	// Obliczenia końcowe
+	var proteinsPerKg float64
+	if weight > 0 {
+		proteinsPerKg = summary.Proteins / weight
+	}
+	var fatPercent float64
+	if summary.Kcal > 0 {
+		fatPercent = (summary.Fats * 9 / summary.Kcal) * 100
+	}
 	left := model.Left{
 		Kcal:     goal - summary.Kcal,
-		Proteins: summary.Proteins / weight,
-		Fats:     (summary.Fats * 9 / summary.Kcal) * 100, // % kcal z tłuszczu
+		Proteins: proteinsPerKg,
+		Fats:     fatPercent, // % kcal z tłuszczu
 	}
 
 	resp := model.DaySummaryResponse{


### PR DESCRIPTION
## Summary
- avoid division by zero when calculating day summary in tools service

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687a0b2a1c5083329c9c9efbdd434405